### PR TITLE
Fixed dragging bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ sizeSlider.onmousemove = (e) => changeSizeText();
 let mouseDown = false;
 document.body.onmousedown = () => (mouseDown = true);
 document.body.onmouseup = () => (mouseDown = false);
+document.body.onmouseleave = () => (mouseDown = false); // when the cursor leaves the window
 function makeGrid(size) {
   etchGrid = document.getElementById("etchGrid");
   while (etchGrid.firstChild) {
@@ -21,7 +22,6 @@ function makeGrid(size) {
     block.classList.add("gridBlock", "gridBlockBorder");
     block.addEventListener("mouseover", changeBlock);
     block.addEventListener("mousedown", changeBlock);
-    block.setAttribute('draggable', false);
     etchGrid.appendChild(block);
   }
 }

--- a/style.css
+++ b/style.css
@@ -73,6 +73,7 @@ button:hover {
 .gridBlock {
   padding: 0;
   margin: 0;
+  user-select: none;
 }
 .gridBlockBorder {
   border: 1px solid black;


### PR DESCRIPTION
Hi, I believe that this should fix your click and drag bug. This was caused by accidental "highlighting" of the divs, when you drag highlighted elements it "copies" them hence causing the bug. This is (to my understanding) the same way you could highlight text and then click and drag it to copy the text into a text field. To fix this you can just add [`user-select: none`](https://developer.mozilla.org/en-US/docs/Web/CSS/user-select) to the gridBlock class. 

I also fixed the bug where the cursor would stay 'clicked' when the mouse left the window it is an easy fix, the [onmouseleave event](https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseleave_event) is what you were probably looking for.